### PR TITLE
Identify case number before processing

### DIFF
--- a/pkg/common/salesforce.go
+++ b/pkg/common/salesforce.go
@@ -59,17 +59,17 @@ func (sf *BaseSalesforceClient) GetCaseByNumber(number string) (*Case, error) {
 	return nil, fmt.Errorf("Not found case with number: %s", number)
 }
 
-func GetCaseNumberByFilename(filename string) (string, error) {
+func GetCaseNumberFromFilename(filename string) (string, error) {
 	regex, err := regexp.Compile(`(\d{6,})`)
 	if err != nil {
 		return "", err
 	}
 
 	for _, candidate := range regex.FindAll([]byte(filename), 1) {
-		if len(candidate) <= 8 {
+		if len(candidate) <= 8 && len(candidate) > 0 {
 			return string(candidate), nil
 		}
 	}
 
-	return "", fmt.Errorf("Not found case number on: %s", filename)
+	return "", fmt.Errorf("Could not identify case number from filename '%s'", filename)
 }

--- a/pkg/monitor/monitor.go
+++ b/pkg/monitor/monitor.go
@@ -75,12 +75,14 @@ func (m *Monitor) GetMatchingProcessorByFile(files []db.File) (map[string][]db.F
 	for _, file := range files {
 		var processors []string
 
-		caseNumber, err := common.GetCaseNumberByFilename(file.Path)
-		if err == nil && caseNumber != "" {
+		caseNumber, err := common.GetCaseNumberFromFilename(file.Path)
+		if err == nil {
 			sfCase, err = m.SalesforceClient.GetCaseByNumber(caseNumber)
 			if err != nil {
 				log.Error(err)
 			}
+		} else {
+			log.Error(err)
 		}
 
 		if sfCase != nil {

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -57,9 +57,11 @@ func (s *ProcessorTestSuite) TestRunProcessor() {
 
 	b, _ := json.Marshal(db.File{Path: "/uploads/sosreport-123.tar.xz"})
 	b1, _ := json.Marshal(db.File{Path: "/uploads/sosreport-321.tar.xz"})
+	b2, _ := json.Marshal(db.File{Path: "/uploads/sosreport-abc.tar.xz"})
 
 	_ = provider.Publish(context.Background(), "sosreports", &pubsub.Msg{Data: b})
 	_ = provider.Publish(context.Background(), "sosreports", &pubsub.Msg{Data: b1})
+	_ = provider.Publish(context.Background(), "sosreports", &pubsub.Msg{Data: b2})
 
 	var called = 0
 
@@ -79,8 +81,8 @@ func (s *ProcessorTestSuite) TestRunProcessor() {
 		return &subscriber
 	})
 
-	assert.Equal(s.T(), called, 2)
-	assert.Equal(s.T(), len(provider.Msgs["sosreports"]), 2)
+	assert.Equal(s.T(), called, 3)
+	assert.Equal(s.T(), len(provider.Msgs["sosreports"]), 3)
 }
 
 func TestNewProcessor(t *testing.T) {


### PR DESCRIPTION
Always attempt to identify before processing
to avoid wasting cycles.

Resolves: #43