### PR TITLE
Enable Ubuntu Pro in docker images

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -67,6 +67,8 @@ jobs:
           labels: ${{ steps.processor_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            "pro_attach_config=${{ secrets.PRO_ATTACH_CONFIG }}"
 
       - name: Extract Docker metadata - monitor
         id: monitor_meta
@@ -86,3 +88,5 @@ jobs:
           labels: ${{ steps.monitor_meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            "pro_attach_config=${{ secrets.PRO_ATTACH_CONFIG }}"

--- a/Makefile.common
+++ b/Makefile.common
@@ -233,10 +233,11 @@ common-tarball: promu
 .PHONY: common-docker $(BUILD_DOCKER_IMAGES)
 common-docker: $(BUILD_DOCKER_IMAGES)
 $(BUILD_DOCKER_IMAGES): common-docker-%:
-	docker build -t "$(DOCKER_REPO)/athena-$*-linux-$(DOCKER_ARCHS):$(DOCKER_IMAGE_TAG)" \
+	DOCKER_BUILDKIT=1 docker build -t "$(DOCKER_REPO)/athena-$*-linux-$(DOCKER_ARCHS):$(DOCKER_IMAGE_TAG)" \
 		-f ./cmd/$*/$(DOCKERFILE_PATH) \
 		--build-arg ARCH=$(DOCKER_ARCHS) \
 		--build-arg OS="linux" \
+		--secret id=pro_attach_config,src=pro-attach-config.yaml \
 		$(DOCKERBUILD_CONTEXT)
 
 .PHONY: common-docker-publish $(PUBLISH_DOCKER_IMAGES)

--- a/cmd/monitor/Dockerfile
+++ b/cmd/monitor/Dockerfile
@@ -1,8 +1,57 @@
-
 FROM ubuntu:20.04
 LABEL maintainer="Canonical Sustaining Engineering <edward.hope-morley@canonical.com>"
 
-RUN apt update -yyq && apt -yyq install ca-certificates git xz-utils python3 python3-yaml coreutils bsdmainutils jq bc python3-simplejson
+# Reference: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/enable_in_dockerfile.html
+RUN --mount=type=secret,id=pro_attach_config \
+    # First we update apt so we install the correct versions of packages in
+    # the next step
+    apt-get update \
+    #
+    # Here we install `pro` (ubuntu-advantage-tools) as well as ca-certificates,
+    # which is required to talk to the Ubuntu Pro authentication server securely.
+    && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
+    #
+    # With pro installed, we attach using our attach config file from the
+    # previous step
+    && (if grep -q ^token /run/secrets/pro_attach_config; then pro attach --attach-config /run/secrets/pro_attach_config; fi) \
+    #
+    ###########################################################################
+    # At this point, the container has access to all Ubuntu Pro services
+    # specified in the attach config file.
+    ###########################################################################
+    #
+    # Always upgrade all packages to the latest available version with the Ubuntu Pro
+    # services enabled.
+    && apt-get upgrade -y \
+    #
+    # Then, you can install any specific packages you need for your docker
+    # container.
+    # Install them here, while Ubuntu Pro is enabled, so that you get the appropriate
+    # versions.
+    # Any `apt-get install ...` commands you have in an existing Dockerfile
+    # that you may be migrating to use Ubuntu Pro should probably be moved here.
+    && apt-get install -y ca-certificates git xz-utils python3 python3-yaml coreutils bsdmainutils jq bc python3-simplejson \
+    #
+    ###########################################################################
+    # Now that we have upgraded and installed any packages from the Ubuntu Pro
+    # services, we can clean up.
+    ###########################################################################
+    #
+    # This purges ubuntu-advantage-tools, including all Ubuntu Pro related
+    # secrets from the system.
+    ###########################################################################
+    # IMPORTANT: As written here, this command assumes your container does not
+    # need ca-certificates so it is purged as well.
+    # If your container needs ca-certificates, then do not purge it from the
+    # system here.
+    ###########################################################################
+    && apt-get purge --auto-remove -y ubuntu-advantage-tools \
+    #
+    # Finally, we clean up the apt lists which should not be needed anymore
+    # because any `apt-get install`s should have happened above. Cleaning these
+    # lists keeps your image smaller.
+    && rm -rf /var/lib/apt/lists/*
+
 RUN update-ca-certificates
 RUN mkdir /etc/athena/
 

--- a/cmd/processor/Dockerfile
+++ b/cmd/processor/Dockerfile
@@ -1,7 +1,57 @@
 FROM ubuntu:20.04
 LABEL maintainer="Canonical Sustaining Engineering <edward.hope-morley@canonical.com>"
 
-RUN apt update -yyq && apt -yyq install ca-certificates git xz-utils python3 python3-yaml coreutils bsdmainutils jq bc python3-simplejson python3-pip patool
+# Reference: https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/enable_in_dockerfile.html
+RUN --mount=type=secret,id=pro_attach_config \
+    # First we update apt so we install the correct versions of packages in
+    # the next step
+    apt-get update \
+    #
+    # Here we install `pro` (ubuntu-advantage-tools) as well as ca-certificates,
+    # which is required to talk to the Ubuntu Pro authentication server securely.
+    && apt-get install --no-install-recommends -y ubuntu-advantage-tools ca-certificates \
+    #
+    # With pro installed, we attach using our attach config file from the
+    # previous step
+    && (if grep -q ^token /run/secrets/pro_attach_config; then pro attach --attach-config /run/secrets/pro_attach_config; fi) \
+    #
+    ###########################################################################
+    # At this point, the container has access to all Ubuntu Pro services
+    # specified in the attach config file.
+    ###########################################################################
+    #
+    # Always upgrade all packages to the latest available version with the Ubuntu Pro
+    # services enabled.
+    && apt-get upgrade -y \
+    #
+    # Then, you can install any specific packages you need for your docker
+    # container.
+    # Install them here, while Ubuntu Pro is enabled, so that you get the appropriate
+    # versions.
+    # Any `apt-get install ...` commands you have in an existing Dockerfile
+    # that you may be migrating to use Ubuntu Pro should probably be moved here.
+    && apt-get install -y ca-certificates git xz-utils python3 python3-yaml coreutils bsdmainutils jq bc python3-simplejson python3-pip patool \
+    #
+    ###########################################################################
+    # Now that we have upgraded and installed any packages from the Ubuntu Pro
+    # services, we can clean up.
+    ###########################################################################
+    #
+    # This purges ubuntu-advantage-tools, including all Ubuntu Pro related
+    # secrets from the system.
+    ###########################################################################
+    # IMPORTANT: As written here, this command assumes your container does not
+    # need ca-certificates so it is purged as well.
+    # If your container needs ca-certificates, then do not purge it from the
+    # system here.
+    ###########################################################################
+    && apt-get purge --auto-remove -y ubuntu-advantage-tools \
+    #
+    # Finally, we clean up the apt lists which should not be needed anymore
+    # because any `apt-get install`s should have happened above. Cleaning these
+    # lists keeps your image smaller.
+    && rm -rf /var/lib/apt/lists/*
+
 RUN update-ca-certificates
 RUN mkdir /etc/athena/
 

--- a/pro-attach-config.yaml
+++ b/pro-attach-config.yaml
@@ -1,0 +1,14 @@
+# If a non-commented "token:" line exists in the secret but the attachment
+# fails, the build will error. However if no token exists it will not
+# error and build without Ubuntu Pro. This is to ensure the GitHub action
+# fails if the token becomes invalid but also allows for local development
+# without a token.
+
+# Uncomment the following lines and insert your TOKEN from
+# https://ubuntu.com/pro/dashboard to enable Ubuntu Pro in the docker image
+# build
+
+#token: TOKEN
+#enable_services:
+#  - esm-infra
+#  - esm-apps


### PR DESCRIPTION
Build docker images with Ubuntu Pro to get relevant security fixes.

If a non-commented "token:" line exists in the secret but the attachment
fails, the build will error. However if no token exists it will not
error and build without Ubuntu Pro. This is to ensure the GitHub action
fails if the token becomes invalid but also allows for local development
without a token.

For local builds, the file pro-attach-config.yaml is used. Set a token
to build with Ubuntu Pro.

For GitHub actions, create a secret called PRO_ATTACH_CONFIG with the
same contents as as pro-attach-config.yaml file.

Closes: #48
