### PR TITLE
Increase linter timeout

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -82,7 +82,7 @@ PROMU_VERSION ?= 0.15.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 GOLANGCI_LINT :=
-GOLANGCI_LINT_OPTS ?=
+GOLANGCI_LINT_OPTS ?= --timeout 5m
 GOLANGCI_LINT_VERSION ?= v1.54.2
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.


### PR DESCRIPTION
CI is failing with the default timeout.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
