### PR TITLE
Do not deamonize for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ DOCKER_IMAGE_NAMES ?= processor monitor
 include Makefile.common
 
 docker-compose:
-	docker-compose down --remove-orphans && docker-compose up --force-recreate -d --build
+	docker-compose down --remove-orphans && docker-compose up --force-recreate --build
 
 devel:  common-build common-docker docker-compose


### PR DESCRIPTION
For development and testing it is easire to not daemonize the
docker-compose deployment so that log files are simply printed to
console.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
