### PR TITLE
Use docker images built in current branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ DOCKER_IMAGE_NAMES ?= processor monitor
 include Makefile.common
 
 docker-compose:
-	docker-compose down --remove-orphans && docker-compose up --force-recreate -d --build
+	docker-compose down --remove-orphans
+	BRANCH=$(shell git branch --show-current) docker-compose up --force-recreate --build
 
 devel:  common-build common-docker docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 
   athena-monitor:
     container_name: athena-monitor
-    image: athena/athena-monitor-linux-amd64:main
+    image: athena/athena-monitor-linux-amd64:${BRANCH:-main}
     volumes:
       - ./development-config.yaml:/etc/athena/main.yaml
     command: /athena-monitor --log.level="debug"
@@ -45,7 +45,7 @@ services:
 
   athena-processor:
     container_name: athena-processor
-    image: athena/athena-processor-linux-amd64:main
+    image: athena/athena-processor-linux-amd64:${BRANCH:-main}
     volumes:
       - ./development-config.yaml:/etc/athena/main.yaml
     command: /athena-processor --config /etc/athena/main.yaml --log.level="debug"


### PR DESCRIPTION
For testing, we need to use the images built in the current branch. This
is not always the main branch.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
