### PR TITLE
Download files in monitor

### DIFF
--- a/pkg/common/test/client.go
+++ b/pkg/common/test/client.go
@@ -33,5 +33,5 @@ func (fc *FilesComClient) GetFiles(dirs []string) ([]db.File, error) {
 }
 
 func (fc *FilesComClient) Download(toDownload *db.File, downloadPath string) (*files_sdk.File, error) {
-	return nil, nil
+	return &files_sdk.File{}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 		PollEvery    string   `yaml:"poll-every" default:"5"`
 		FilesDelta   string   `yaml:"files-delta" default:"10m"`
 		Filetypes    []string `yaml:"filetypes"`
+		BaseTmpDir   string   `yaml:"base-tmpdir" default:""`
 		Directories  []string `yaml:"directories"`
 		ProcessorMap []struct {
 			Type      string `yaml:"type"`


### PR DESCRIPTION
This change tried to address potential race conditions between Athena
and the file mover. The idea is to download new sos reports in the
monitor and park them in a common filesystem. The processor eventually
proceeds with processing the files from the common filesystem.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
