### PR TITLE
Make `--no-cache` option optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ docker-build-monitor docker-build-processor: docker-build-%:
 	docker build \
 	    --tag athena/athena-$*-linux-amd64:$(subst /,-,$(shell git rev-parse --abbrev-ref HEAD)) \
 		--file cmd/$*/Dockerfile \
-		--no-cache \
+		$(if $(NOCACHE),--no-cache,) \
 		--build-arg ARCH=amd64 \
 		--build-arg OS=linux \
 		.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,10 @@ And finally run
 ```shell
 make devel
 ```
+
+In case the `docker-build` step fails you can try to re-run the `make` command
+without using the cache,
+
+```shell
+NOCACHE=1 make devel
+```


### PR DESCRIPTION
During development, it is much faster to use the cache when building the
images. Because the cache can be outdated sufficiently that the image
build fails, this change makes the `--no-cache` option configurable. The
cache is used by default but can be disabled by setting the `NOCACHE`
environment variable.

    NOCACHE=1 make docker-build

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
