### PR TITLE
Add debug container

### DIFF
--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+LABEL maintainer="Canonical Sustaining Engineering <edward.hope-morley@canonical.com>"
+LABEL org.opencontainers.image.description "Athena Monitor"
+
+RUN apt-get update
+RUN apt-get install --no-install-recommends --yes \
+    iproute2 \
+    iputils-ping
+RUN apt-get update
+RUN apt-get install --no-install-recommends --yes \
+    default-mysql-client

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ docker-compose:
 devel:  athena-monitor athena-processor docker-build docker-compose
 
 .PHONY: common-docker monitor processor
-docker-build: athena-monitor docker-build-monitor athena-processor docker-build-processor
+docker-build: athena-monitor docker-build-monitor athena-processor docker-build-processor debug-container
 
 .PHONY: docker-build-monitor docker-build-processor
 docker-build-monitor docker-build-processor: docker-build-%:
@@ -31,6 +31,13 @@ docker-build-monitor docker-build-processor: docker-build-%:
 		$(if $(NOCACHE),--no-cache,) \
 		--build-arg ARCH=amd64 \
 		--build-arg OS=linux \
+		.
+
+.PHONY: debug-container
+debug-container:
+	docker build \
+		--tag debug-container \
+		--file Dockerfile-debug \
 		.
 
 .PHONY: build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,14 @@ services:
       - athena
     restart: always
 
+  debug:
+    container_name: debug
+    image: debug-container
+    command: /bin/bash -c 'sleep 10000'
+    networks:
+      - athena
+    restart: always
+
 networks:
   athena:
     driver: bridge


### PR DESCRIPTION
This container is on the same network as the other containers and can be
used to connect to the mysql database for example.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
