### PR TITLE
[SET-626] Split large comments into chunks

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestNewDb(t *testing.T) {
+	db := NewDb()
+
+	if db.Dialect != "sqlite" {
+		t.Errorf("Expected Dialect to be 'sqlite', got '%s'", db.Dialect)
+	}
+
+	if db.DSN != "" {
+		t.Errorf("Expected DSN to be '', got '%s'", db.DSN)
+	}
+}
+
+func TestNewMonitor(t *testing.T) {
+	monitor := NewMonitor()
+
+	if monitor.PollEvery != "5" {
+		t.Errorf("Expected PollEvery to be '5', got '%s'", monitor.PollEvery)
+	}
+
+	if monitor.FilesDelta != "10m" {
+		t.Errorf("Expected FilesDelta to be '10m', got '%s'", monitor.FilesDelta)
+	}
+
+	if len(monitor.Filetypes) != 0 {
+		t.Errorf("Expected Filetypes to be empty, got '%v'", monitor.Filetypes)
+	}
+
+	if monitor.BaseTmpDir != "" {
+		t.Errorf("Expected BaseTmpDir to be '', got '%s'", monitor.BaseTmpDir)
+	}
+
+	if len(monitor.Directories) != 0 {
+		t.Errorf("Expected Directories to be empty, got '%v'", monitor.Directories)
+	}
+
+	if len(monitor.ProcessorMap) != 0 {
+		t.Errorf("Expected ProcessorMap to be empty, got '%v'", monitor.ProcessorMap)
+	}
+}
+
+func TestNewProcessor(t *testing.T) {
+	processor := NewProcessor()
+
+	if processor.ReportsUploadPath != "/customers/athena-reports/" {
+		t.Errorf("Expected ReportsUploadPath to be '/customers/athena-reports/', got '%s'", processor.ReportsUploadPath)
+	}
+
+	if processor.BatchCommentsEvery != "10m" {
+		t.Errorf("Expected BatchCommentsEvery to be '10m', got '%s'", processor.BatchCommentsEvery)
+	}
+
+	if processor.BaseTmpDir != "" {
+		t.Errorf("Expected BaseTmpDir to be '', got '%s'", processor.BaseTmpDir)
+	}
+
+	if len(processor.SubscribeTo) != 0 {
+		t.Errorf("Expected SubscribeTo to be empty, got '%v'", processor.SubscribeTo)
+	}
+}
+
+func TestNewSalesforce(t *testing.T) {
+	salesforce := NewSalesForce()
+
+	if salesforce.Endpoint != "" {
+		t.Errorf("Expected Endpoint to be '', got '%s'", salesforce.Endpoint)
+	}
+
+	if salesforce.Username != "" {
+		t.Errorf("Expected Username to be '', got '%s'", salesforce.Username)
+	}
+
+	if salesforce.Password != "" {
+		t.Errorf("Expected Password to be '', got '%s'", salesforce.Password)
+	}
+
+	if salesforce.SecurityToken != "" {
+		t.Errorf("Expected SecurityToken to be '', got '%s'", salesforce.SecurityToken)
+	}
+
+	if salesforce.MaxCommentLength != 3000 {
+		t.Errorf("Expected MaxCommentLength to be 3000, got '%d'", salesforce.MaxCommentLength)
+	}
+}
+
+func TestNewConfigFromFile(t *testing.T) {
+	// Create a temporary file
+	tempFile, err := ioutil.TempFile("", "config.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile.Name()) // Clean up
+
+	// Write some YAML content to the file
+	yamlContent := `
+db:
+  dialect: postgres
+monitor:
+  poll-every: 10
+  files-delta: 20m
+`
+	if _, err := tempFile.Write([]byte(yamlContent)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tempFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call NewConfigFromFile with the path of the temporary file
+	config, err := NewConfigFromFile([]string{tempFile.Name()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check if the config has the expected values
+	if config.Db.Dialect != "postgres" {
+		t.Errorf("Expected Db.Dialect to be 'postgres', got '%s'", config.Db.Dialect)
+	}
+
+	if config.Monitor.PollEvery != "10" {
+		t.Errorf("Expected Monitor.PollEvery to be '10', got '%s'", config.Monitor.PollEvery)
+	}
+
+	if config.Monitor.FilesDelta != "20m" {
+		t.Errorf("Expected Monitor.FilesDelta to be '20m', got '%s'", config.Monitor.FilesDelta)
+	}
+
+	if config.Salesforce.MaxCommentLength != 3000 {
+		t.Errorf("Expected MaxCommentLength to be 3000, got '%d'", config.Salesforce.MaxCommentLength)
+	}
+}

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -3,6 +3,10 @@ package processor
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"testing"
+	"time"
+
 	"github.com/canonical/athena-core/pkg/common"
 	"github.com/canonical/athena-core/pkg/common/db"
 	"github.com/canonical/athena-core/pkg/common/test"
@@ -15,9 +19,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"io/ioutil"
-	"testing"
-	"time"
 )
 
 type ProcessorTestSuite struct {
@@ -88,4 +89,29 @@ func (s *ProcessorTestSuite) TestRunProcessor() {
 
 func TestNewProcessor(t *testing.T) {
 	suite.Run(t, &ProcessorTestSuite{})
+}
+
+func TestSplitComment(t *testing.T) {
+	var inputs []string = []string{
+		"123456789\n",
+		"1234\n567890\n123\n",
+		"1234567890123456789",
+	}
+	var expected [][]string = [][]string{
+		{
+			"123456789\n",
+		},
+		{
+			"1234\n567890",
+			"123",
+		},
+		{
+			"1234567890123456789",
+		},
+	}
+	var got []string = []string{}
+	for i, input := range inputs {
+		got = splitComment(input, 12)
+		assert.Equal(t, expected[i], got)
+	}
 }


### PR DESCRIPTION
Salesforce restricts the size of a comment to 4000 charactes. This
change adds a function that splits comments into chunks no larger than
4000 characters. The chunks are posted in separate comments. The chunk
size is configurable to allow for future changes in how Salesforce
restricts comments.

Closes: https://github.com/canonical/athena-core/issues/121
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
