### PR TITLE
Update DB schema to allow for long outputs

### DIFF
--- a/pkg/common/db/file.go
+++ b/pkg/common/db/file.go
@@ -1,8 +1,9 @@
 package db
 
 import (
-	"gorm.io/gorm"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type File struct {
@@ -31,7 +32,7 @@ type Report struct {
 type Script struct {
 	gorm.Model
 
-	Output         string `gorm:"type:text"`
+	Output         string `gorm:"type:longtext"`
 	Name           string
 	UploadLocation string
 	ReportID       uint


### PR DESCRIPTION
Some `hotsos` outputs are too long to fit into a regular text field.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
