### PR TITLE
Fix default script timeout

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -62,6 +62,7 @@ type ReportRunner struct {
 }
 
 func RunWithTimeout(baseDir string, timeout time.Duration, command string) ([]byte, error) {
+	log.Debugf("Running script with %s timeout", timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
@@ -75,6 +76,7 @@ func RunWithTimeout(baseDir string, timeout time.Duration, command string) ([]by
 }
 
 func RunWithoutTimeout(baseDir string, command string) ([]byte, error) {
+	log.Debug("Running script without timeout")
 	cmd := exec.Command("bash", "-c", command)
 	cmd.Dir = baseDir
 	return cmd.CombinedOutput()
@@ -212,7 +214,7 @@ func (runner *ReportRunner) Run(reportFn func(report *ReportToExecute) (map[stri
 	return nil
 }
 
-const DefaultExecutionTimeout = "5m"
+const DefaultExecutionTimeout = "0s"
 
 func renderTemplate(ctx *pongo2.Context, data string) (string, error) {
 	tpl, err := pongo2.FromString(data)


### PR DESCRIPTION
The default is no timeout.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
