### PR TITLE
Update collation

### DIFF
--- a/pkg/common/db/conn.go
+++ b/pkg/common/db/conn.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/canonical/athena-core/pkg/config"
+	log "github.com/sirupsen/logrus"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -24,6 +25,28 @@ func GetDBConn(cfg *config.Config) (*gorm.DB, error) {
 		return nil, err
 	}
 
-	dbInstance.AutoMigrate(File{}, Report{}, Script{})
+	switch cfg.Db.Dialect {
+	case "sqlite":
+		log.Debugln("Will not change collation")
+		dbInstance.AutoMigrate(File{}, Report{}, Script{})
+	case "mysql":
+		var lockName = "migrate_lock"
+		var timeout = 10 // seconds
+		var lock int
+		dbInstance.Raw("SELECT GET_LOCK(?, ?)", lockName, timeout).Scan(&lock)
+		if lock == 1 {
+			if !dbInstance.Migrator().HasColumn(&File{}, "Path") {
+				log.Debugln("Changing collation to UTF-8")
+				dbInstance.AutoMigrate(File{}, Report{}, Script{})
+				err = dbInstance.Exec("ALTER TABLE files MODIFY Path VARCHAR(10240) CHARACTER SET utf8 COLLATE utf8_general_ci").Error
+				if err != nil {
+					log.Errorln("Could not change collation of files table")
+				}
+			}
+			dbInstance.Exec("DO RELEASE_LOCK(?)", lockName)
+		} else {
+			log.Errorln("Could not get lock on database")
+		}
+	}
 	return dbInstance, nil
 }


### PR DESCRIPTION
Files.com does not always return a UTF-8 encoded path. This leads to
mysql errors because the corresponding field in the database are UTF-8
formatted. This change modifies the field such that encodings other than
UTF-8 can be compared with the field.

Closes: SET-600
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
