### PR TITLE
[SET-627] Enable chatter

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -29,7 +29,6 @@ func init() {
 }
 
 func main() {
-
 	cfg, err := config.NewConfigFromFile(*configs)
 	if err != nil {
 		panic(err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,11 +76,13 @@ type SalesForce struct {
 	Password         string `yaml:"password"`
 	SecurityToken    string `yaml:"security-token"`
 	MaxCommentLength int    `yaml:"max-comment-length"`
+	EnableChatter    bool   `yaml:"enable-chatter"`
 }
 
 func NewSalesForce() SalesForce {
 	return SalesForce{
 		MaxCommentLength: 4000 - 1000, // A very conservative buffer of max length per Salesforce comment (4000) without header text for comments
+		EnableChatter:    false,
 	}
 }
 
@@ -129,8 +131,8 @@ func NewConfigFromFile(filePaths []string) (*Config, error) {
 
 	if err := s.Snuffle(); err != nil {
 		return nil, err
-
 	}
+
 	return &config, nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -88,6 +88,10 @@ func TestNewSalesforce(t *testing.T) {
 	if salesforce.MaxCommentLength != 3000 {
 		t.Errorf("Expected MaxCommentLength to be 3000, got '%d'", salesforce.MaxCommentLength)
 	}
+
+	if salesforce.EnableChatter {
+		t.Errorf("Expected EnableChatter to be false, got true")
+	}
 }
 
 func TestNewConfigFromFile(t *testing.T) {


### PR DESCRIPTION
This change adds a configuration option to post comments to a chatter
object instead of a casecomment object. The feature is disabled by
default and has to be explicitly enabled via the configuration file:

```yaml
salesforce:
  enable-chatter: true
```

The change also introduces the `salesforce-test` binary to test
Salesforce queries.

Closes: SET-627
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
