### PR TITLE
Add `tmp` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-*.db
 .idea*
-vendor/*
+*.db
 data/*
 example-config.yaml
+tmp/*
+vendor/*


### PR DESCRIPTION
Which is used when running `make devel` locally.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
