### PR TITLE
Allow for failures in script

### DIFF
--- a/athena-processor.yaml
+++ b/athena-processor.yaml
@@ -37,14 +37,13 @@ processor:
                 set -e -u
                 pipx install hotsos &>/dev/null
                 pipx upgrade hotsos &>/dev/null
-                tar -xf {{filepath}} -C {{basedir}} &>/dev/null
-                ~/.local/bin/hotsos --save --output-path hotsos-out --all-logs {{basedir}}/$(basename {{filepath}} .tar.xz)/ &>/dev/null
+                tar -xf {{filepath}} -C {{basedir}} &>/dev/null || true
+                ~/.local/bin/hotsos --save --output-path hotsos-out --all-logs {{basedir}}/$(basename {{filepath}} .tar.xz)/ &>/dev/null || true
                 if [ -s hotsos-out/*/summary/full/yaml/hotsos-summary.all.yaml ]; then
                   cat hotsos-out/*/summary/full/yaml/hotsos-summary.all.yaml
                 else
                   echo "No full sosreport generated."
                 fi
-                rm -rf hotsos-out
                 exit 0
             hotsos-short:
               exit-codes: 0 2 127 126
@@ -53,12 +52,11 @@ processor:
                 set -e -u
                 pipx install hotsos &>/dev/null
                 pipx upgrade hotsos &>/dev/null
-                tar -xf {{filepath}} -C {{basedir}} &>/dev/null
-                ~/.local/bin/hotsos --short --save --output-path hotsos-out --all-logs {{basedir}}/$(basename {{filepath}} .tar.xz)/ &>/dev/null
+                tar -xf {{filepath}} -C {{basedir}} &>/dev/null || true
+                ~/.local/bin/hotsos --short --save --output-path hotsos-out --all-logs {{basedir}}/$(basename {{filepath}} .tar.xz)/ &>/dev/null || true
                 if [ -s hotsos-out/*/summary/short/yaml/hotsos-summary.all.yaml ]; then
                   cat hotsos-out/*/summary/short/yaml/hotsos-summary.all.yaml
                 else
                   echo "No known bugs or issues found on sosreport."
                 fi
-                rm -rf hotsos-out
                 exit 0

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -63,12 +63,11 @@ type ReportRunner struct {
 }
 
 func RunWithTimeout(baseDir string, timeout time.Duration, command string) ([]byte, error) {
-	log.Debugf("Running script with %s timeout", timeout)
+	log.Debugf("Running script with %s timeout in %s", timeout, baseDir)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bash", "-c", command)
 	cmd.Dir = baseDir
-
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		return nil, nil
@@ -77,7 +76,7 @@ func RunWithTimeout(baseDir string, timeout time.Duration, command string) ([]by
 }
 
 func RunWithoutTimeout(baseDir string, command string) ([]byte, error) {
-	log.Debug("Running script without timeout")
+	log.Debugf("Running script without timeout in %s", baseDir)
 	cmd := exec.Command("bash", "-c", command)
 	cmd.Dir = baseDir
 	return cmd.CombinedOutput()
@@ -95,6 +94,7 @@ func RunReport(report *ReportToExecute) (map[string][]byte, error) {
 		} else {
 			ret, err = RunWithoutTimeout(report.BaseDir, script)
 		}
+		log.Debugf("Script '%s' on '%s' completed", scriptName, filepath.Base(report.FileName))
 		if err != nil {
 			log.Errorf("Error occurred (test) while running script: %s", err)
 			for _, line := range strings.Split(string(ret), "\n") {


### PR DESCRIPTION
Tar sometimes fails (for example when it cannot create a special file)
which is something the script should ignore. This change is
unfortunately quite broad and does not address more subtle failures
which the script might not want to ignore.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
