### PR TITLE
Update workflow triggers

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,10 +1,6 @@
 name: Publish to Docker Hub
 
 on:
-  workflow_run:
-    workflows: [Test and Build]
-    types:
-      - completed
   release:
     types:
       - published

--- a/.github/workflows/ghcr-publish.yaml
+++ b/.github/workflows/ghcr-publish.yaml
@@ -1,10 +1,6 @@
 name: Publish to ghcr.io
 
 on:
-  workflow_run:
-    workflows: [Test and Build]
-    types:
-      - completed
   release:
     types:
       - published


### PR DESCRIPTION
We do not need to publish images for every push to the repository.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
