### PR TITLE
Do not re-use connections

### DIFF
--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -40,22 +40,14 @@ func main() {
 		log.Debug(line)
 	}
 
-	filesClient, err := common.NewFilesComClient(cfg.FilesCom.Key, cfg.FilesCom.Endpoint)
-	if err != nil {
-		panic(err)
-	}
-
-	sfClient, err := common.NewSalesforceClient(cfg)
-	if err != nil {
-		panic(err)
-	}
-
 	natsClient, err := nats.NewNats("test-cluster", stan.NatsURL(*natsUrl))
 	if err != nil {
 		panic(err)
 	}
 
-	m, err := monitor.NewMonitor(filesClient, sfClient, natsClient, cfg, nil)
+	salesforceClientFactory := &common.BaseSalesforceClientFactory{}
+	filesComClientFactory := &common.BaseFilesComClientFactory{}
+	m, err := monitor.NewMonitor(natsClient, cfg, nil, salesforceClientFactory, filesComClientFactory)
 	if err != nil {
 		panic(err)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     container_name: athena-monitor
     image: ghcr.io/canonical/athena-core/athena-monitor:${BRANCH:-main}
     volumes:
-      - ./creds.yaml:/etc/athena/main.yaml
+      - ./creds-athena.yaml:/etc/athena/main.yaml
       - ./athena-monitor.yaml:/etc/athena/monitor.yaml
       - ./athena-monitor-directories.yaml:/etc/athena/monitor-directories.yaml
       - ./tmp:/tmp/athena
@@ -39,7 +39,7 @@ services:
     container_name: athena-processor
     image: ghcr.io/canonical/athena-core/athena-processor:${BRANCH:-main}
     volumes:
-      - ./creds.yaml:/etc/athena/main.yaml
+      - ./creds-athena.yaml:/etc/athena/main.yaml
       - ./athena-processor.yaml:/etc/athena/processor.yaml
       - ./athena-processor-upload.yaml:/etc/athena/processor-upload.yaml
       - ./tmp:/tmp/athena

--- a/pkg/common/files-com.go
+++ b/pkg/common/files-com.go
@@ -22,9 +22,19 @@ type FilesComClient interface {
 	Upload(contents, destinationPath string) (*filessdk.File, error)
 }
 
+type FilesComClientFactory interface {
+	NewFilesComClient(apiKey, endpoint string) (FilesComClient, error)
+}
+
 type BaseFilesComClient struct {
 	FilesComClient
 	ApiClient file.Client
+}
+
+type BaseFilesComClientFactory struct{}
+
+func (client *BaseFilesComClientFactory) NewFilesComClient(apiKey, endpoint string) (FilesComClient, error) {
+	return NewFilesComClient(apiKey, endpoint)
 }
 
 func (client *BaseFilesComClient) Upload(contents, destinationPath string) (*filessdk.File, error) {

--- a/pkg/common/salesforce.go
+++ b/pkg/common/salesforce.go
@@ -30,9 +30,15 @@ type SalesforceClient interface {
 	SObject(objectName ...string) *simpleforce.SObject
 }
 
+type SalesforceClientFactory interface {
+	NewSalesforceClient(config *config.Config) (SalesforceClient, error)
+}
+
 type BaseSalesforceClient struct {
 	*simpleforce.Client
 }
+
+type BaseSalesforceClientFactory struct{}
 
 func NewSalesforceClient(config *config.Config) (SalesforceClient, error) {
 	log.Infof("Creating new Salesforce client")
@@ -41,6 +47,10 @@ func NewSalesforceClient(config *config.Config) (SalesforceClient, error) {
 		return nil, err
 	}
 	return &BaseSalesforceClient{client}, nil
+}
+
+func (sf *BaseSalesforceClientFactory) NewSalesforceClient(config *config.Config) (SalesforceClient, error) {
+	return NewSalesforceClient(config)
 }
 
 type Case struct {

--- a/pkg/common/test/client.go
+++ b/pkg/common/test/client.go
@@ -1,10 +1,12 @@
 package test
 
 import (
+	"time"
+
 	files_sdk "github.com/Files-com/files-sdk-go"
 	"github.com/canonical/athena-core/pkg/common"
 	"github.com/canonical/athena-core/pkg/common/db"
-	"time"
+	"github.com/canonical/athena-core/pkg/config"
 )
 
 type SalesforceClient struct {
@@ -15,8 +17,20 @@ func (sf *SalesforceClient) GetCaseByNumber(number string) (*common.Case, error)
 	return nil, nil
 }
 
+type SalesforceClientFactory struct{}
+
+func (sf *SalesforceClientFactory) NewSalesforceClient(config *config.Config) (common.SalesforceClient, error) {
+	return &SalesforceClient{}, nil
+}
+
 type FilesComClient struct {
 	common.BaseFilesComClient
+}
+
+type FilesComClientFactory struct{}
+
+func (fc *FilesComClientFactory) NewFilesComClient(apiKey, endpoint string) (common.FilesComClient, error) {
+	return &FilesComClient{}, nil
 }
 
 var files = []db.File{

--- a/pkg/monitor/monitor_test.go
+++ b/pkg/monitor/monitor_test.go
@@ -35,7 +35,7 @@ func (s *MonitorTestSuite) SetupTest() {
 
 func (s *MonitorTestSuite) TestRunMonitor() {
 	provider := &memory.MemoryProvider{}
-	monitor, err := NewMonitor(&test.FilesComClient{}, &test.SalesforceClient{}, provider, s.config, s.db)
+	monitor, err := NewMonitor(provider, s.config, s.db, &test.SalesforceClientFactory{}, &test.FilesComClientFactory{})
 	assert.Nil(s.T(), err)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -23,22 +23,22 @@ import (
 )
 
 type Processor struct {
-	Db               *gorm.DB
 	Config           *config.Config
+	Db               *gorm.DB
 	FilesClient      common.FilesComClient
-	SalesforceClient common.SalesforceClient
-	Provider         pubsub.Provider
 	Hostname         string
+	Provider         pubsub.Provider
+	SalesforceClient common.SalesforceClient
 }
 
 type BaseSubscriber struct {
+	Config           *config.Config
 	Db               *gorm.DB
+	FilesComClient   common.FilesComClient
+	Name             string
 	Options          pubsub.HandlerOptions
 	Reports          map[string]config.Report
 	SalesforceClient common.SalesforceClient
-	FilesComClient   common.FilesComClient
-	Config           *config.Config
-	Name             string
 }
 
 func (s *BaseSubscriber) Setup(c *pubsub.Client) {
@@ -46,20 +46,20 @@ func (s *BaseSubscriber) Setup(c *pubsub.Client) {
 }
 
 type ReportToExecute struct {
-	Name, BaseDir, Subscriber, FileName string
 	File                                *db.File
+	Name, BaseDir, Subscriber, FileName string
+	Output                              []byte
 	Scripts                             map[string]string
 	Timeout                             time.Duration
-	Output                              []byte
 }
 
 type ReportRunner struct {
 	Config                    *config.Config
-	Reports                   []ReportToExecute
-	SalesforceClient          common.SalesforceClient
+	Db                        *gorm.DB
 	FilescomClient            common.FilesComClient
 	Name, Subscriber, Basedir string
-	Db                        *gorm.DB
+	Reports                   []ReportToExecute
+	SalesforceClient          common.SalesforceClient
 }
 
 func RunWithTimeout(baseDir string, timeout time.Duration, command string) ([]byte, error) {
@@ -391,12 +391,13 @@ func NewProcessor(filesClient common.FilesComClient, salesforceClient common.Sal
 	}
 
 	return &Processor{
+		Config:           cfg,
+		Db:               dbConn,
+		FilesClient:      filesClient,
 		Hostname:         hostname,
 		Provider:         provider,
-		FilesClient:      filesClient,
 		SalesforceClient: salesforceClient,
-		Db:               dbConn,
-		Config:           cfg}, nil
+	}, nil
 }
 
 func (p *Processor) getReportsByTopic(topic string) map[string]config.Report {


### PR DESCRIPTION
In order to avoid stale connections to Salesforce and files.com, do not
re-use those connections (the clients) and rather create new client
connections when needed.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
